### PR TITLE
Use xenial for examples

### DIFF
--- a/.travis.yml.example-full
+++ b/.travis.yml.example-full
@@ -3,7 +3,7 @@
 
 language: cpp
 compiler: gcc
-dist: trusty
+dist: xenial
 
 addons:
   apt:

--- a/.travis.yml.example-mini
+++ b/.travis.yml.example-mini
@@ -3,7 +3,7 @@
 
 language: cpp
 compiler: gcc
-dist: trusty
+dist: xenial
 
 # Minimal set of packages needed to compile EPICS Base
 


### PR DESCRIPTION
Let's use a bit newer distro with newer compilers and libraries
by default. I think with over 3 years xenial is old enough.
I bet people that really need to go back to the GCC 4 age will
figure out how to do that.