### PR TITLE
Overwrite configure/RELEASE

### DIFF
--- a/travis/utils.sh
+++ b/travis/utils.sh
@@ -182,7 +182,7 @@ add_dependency() {
       release=$CACHEDIR/$dirname-$TAG/configure/RELEASE
       if [ -e $release ]
       then
-        grep -q "include \$(TOP)/../RELEASE.local" $release || echo "-include \$(TOP)/../RELEASE.local" >> $release
+        echo "-include \$(TOP)/../RELEASE.local" > $release
       fi
     fi
     # run hook


### PR DESCRIPTION
The current scripts append the line

-include $(TOP)/../RELEASE.local

at the end of the configure/RELEASE file.
While this works for most EPICS modules, there is one drawback:
Definitions like

SUPPORT=/myfavorite/build/server

are not allways overwrtitten (better say undefined).

Fix this and create a configure/RELEASE file which is the same
for all EPICS modules.
Simply overwrite configure/RELEASE with what we want.

Thanks to the EPICS community for this suggestion