### PR TITLE
Move CACHEDIR into $HOME/.cache/EPICS

### DIFF
--- a/travis/build.sh
+++ b/travis/build.sh
@@ -4,7 +4,8 @@ set -e
 # Set VV in .travis.yml to make scripts verbose
 [ "$VV" ] && set -x
 
-CACHEDIR="$HOME/.cache"
+CACHEDIR="$HOME/.cache/EPICS"
+mkdir -p "$CACHEDIR"
 
 eval $(grep "EPICS_BASE=" ${CACHEDIR}/RELEASE.local)
 export EPICS_BASE

--- a/travis/prepare.sh
+++ b/travis/prepare.sh
@@ -21,7 +21,8 @@ readlinkf() { perl -MCwd -e 'print Cwd::abs_path shift' "$1"; }
 
 SCRIPTDIR=$(dirname $(readlinkf $0))
 CURDIR="$PWD"
-CACHEDIR="$HOME/.cache"
+CACHEDIR="$HOME/.cache/EPICS"
+mkdir -p "$CACHEDIR"
 
 # source functions
 . $SCRIPTDIR/utils.sh


### PR DESCRIPTION
I order to be able to test the build scripts locally, before
pushing them somewhere and waiting some minutes, move them
into its own sub-directory under $HOME/.cache:
$HOME/.cache/EPICS

This allows to run `rm -rf $HOME/.cache/EPICS` to get a clean build,
and works on a remote machine as well.
If it does not exit, create it.
Side note: The definition of CACHEDIR is both in build.sh and prepare.sh,
that needs to be cleaned up in a seperate commit.