### PR TITLE
Fix sticky `recurse="--recursive"`

### DIFF
--- a/travis/utils.sh
+++ b/travis/utils.sh
@@ -140,7 +140,12 @@ add_dependency() {
   eval varname=\${${DEP}_VARNAME:=${DEP}}
   eval recursive=\${${DEP}_RECURSIVE:=1}
   recursive=${recursive,,}
-  [ "$recursive" != "0" -a "$recursive" != "no" ] && recurse="--recursive"
+  if [ "$recursive" != "0" -a "$recursive" != "no" ]
+  then
+    recurse="--recursive"
+  else
+    recurse=""
+  fi
 
   # determine if $DEP points to a valid release or branch
   git ls-remote --quiet --exit-code --refs $repourl "$TAG" > /dev/null 2>&1 ||


### PR DESCRIPTION
By default, modules are cloned recursive.
(This is especially important for EPICS base 7).

However, when a module defines e.g. a module does should not be cloned recursive, e.g.
MOTOR_RECURSIVE=NO
then the shell variable "recurse" stays set to "--recurse" running `git clone`

Make the DEP_RECURSIVE work and reset it to an empty string if needed.