### PR TITLE
Don't use bash 4 substitions for upper/lowercase conversions

### DIFF
--- a/travis/prepare.sh
+++ b/travis/prepare.sh
@@ -1,18 +1,6 @@
 #!/bin/bash
 set -e
 
-# The following if clause can be removed for ci-scripts major version 3
-if [ "$TRAVIS_OS_NAME" == osx -a "$BASH_VERSINFO" -lt 4 ]
-then
-    brew install bash
-    if [ $(/usr/local/bin/bash -c 'echo $BASH_VERSINFO') -lt 4 ]
-    then
-        echo "Failed to install a recent bash" >&2
-        exit 1
-    fi
-    exec /usr/local/bin/bash $0 "$@"
-fi
-
 # Set VV in .travis.yml to make scripts verbose
 [ "$VV" ] && set -x
 
@@ -49,7 +37,7 @@ fold_start check.out.dependencies "Checking/cloning dependencies"
 
 for mod in BASE $ADD_MODULES $MODULES
 do
-  mod_uc=${mod^^}
+  mod_uc=$(echo "$mod" | tr "a-z" "A-Z")
   eval add_dependency $mod_uc \${${mod_uc}:=master}
 done
 [ -e ./configure ] && cp ${CACHEDIR}/RELEASE.local ./configure/RELEASE.local
@@ -205,7 +193,7 @@ echo "Module     Tag          Binaries    Commit"
 echo "-----------------------------------------------------------------------------------"
 for mod in base $MODULES $ADD_MODULES
 do
-  mod_uc=${mod^^}
+  mod_uc=$(echo "$mod" | tr "a-z" "A-Z")
   eval tag=\${${mod_uc}}
   eval dir=${CACHEDIR}/\${${mod_uc}_DIRNAME}-$tag
   echo "$modules_to_compile" | grep -q "$dir" && stat="rebuilt" || stat="from cache"

--- a/travis/utils.sh
+++ b/travis/utils.sh
@@ -133,13 +133,13 @@ add_dependency() {
   curdir="$PWD"
   DEP=$1
   TAG=$2
-  dep_lc=${DEP,,}
+  dep_lc=$(echo "$DEP" | tr "A-Z" "a-z")
   eval dirname=\${${DEP}_DIRNAME:=${dep_lc}}
   eval reponame=\${${DEP}_REPONAME:=${dep_lc}}
   eval repourl=\${${DEP}_REPOURL:="https://github.com/\${${DEP}_REPOOWNER:=${REPOOWNER:-epics-modules}}/${reponame}.git"}
   eval varname=\${${DEP}_VARNAME:=${DEP}}
   eval recursive=\${${DEP}_RECURSIVE:=1}
-  recursive=${recursive,,}
+  recursive=$(echo $recursive | tr "A-Z" "a-z")
   local recurse=""
   [ "$recursive" != "0" -a "$recursive" != "no" ] && recurse="--recursive"
 


### PR DESCRIPTION
Some bash-istic parameter expansion is used to convert upper-lower case
or vice versa.
This does not work under bash 3.0, which is default on MacOs boxes.
Use tr instead.