### PR TITLE
Clear empty environment variables

### DIFF
--- a/cue.py
+++ b/cue.py
@@ -13,6 +13,18 @@ import distutils.util
 
 logger = logging.getLogger(__name__)
 
+def prepare_env():
+    '''HACK
+    github actions yaml configuration doesn't allow
+    conditional (un)setting of environments, only values.
+    Currently this script treats unset and empty environment
+    variables differently.
+    While this is the case, we unset any empty environment variables.
+    '''
+    toclear = tuple(k for k,v in os.environ.items() if len(v.strip())==0)
+    for var in toclear:
+        print('{0}Clearing empty environment variable {1}{2}'.format(ANSI_CYAN, var, ANSI_RESET))
+        del os.environ[var]
 
 # Detect the service and set up context hash accordingly
 def detect_context():
@@ -1121,6 +1133,7 @@ def main(raw):
         logging.basicConfig(level=logging.DEBUG)
         silent_dep_builds = False
 
+    prepare_env()
     detect_context()
 
     if args.vcvars and ci['compiler'].startswith('vs'):


### PR DESCRIPTION
Github actions configuration doesn't provide a way to conditionally set/unset environment variables.  So conditional variables end up set with an empty value.  Unfortunately `cue.py` treats unset and empty variables differently.

Rather than (or ahead of) a comprehensive change to replace all of the `if <var> in os.environ`, @ralphlange suggests to simply unset all empty environment variables.

This certainly could have side-effects, but based on my testing, this isn't the case for github actions or appveyor.