### PR TITLE
Fix qualified GCC version builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -50,6 +50,34 @@ jobs:
     - name: Collect and show test results
       run: python cue.py test-results
 
+  build-linux-old:
+    name: ${{ matrix.cmp }} / ${{ matrix.configuration }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    env:
+      CMP: ${{ matrix.cmp }}
+      BCFG: ${{ matrix.configuration }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-16.04]
+        cmp: ["gcc-4.8", "gcc-4.9"]
+        configuration: [default, static]
+    steps:
+    - uses: actions/checkout@v2
+    - name: "apt-get install ${{ matrix.cmp }}"
+      run: |
+        sudo apt-get -y install software-properties-common
+        sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+        sudo apt-get -y install ${{ matrix.cmp }}
+    - name: Prepare and compile dependencies
+      run: python cue.py prepare
+    - name: Build main module (example app)
+      run: python cue.py build
+    - name: Run main module tests
+      run: python cue.py test
+    - name: Collect and show test results
+      run: python cue.py test-results
+
   build-macos:
     name: ${{ matrix.cmp }} / ${{ matrix.configuration }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}

--- a/cue.py
+++ b/cue.py
@@ -878,34 +878,35 @@ RTEMS_BASE={1}'''.format(os.environ['RTEMS'], rtemsdir))
                     f.write('''
 CROSS_COMPILER_TARGET_ARCHS += RTEMS-pc386{0}'''.format(qemu_suffix))
 
-        host_ccmplr_name = re.sub(r'^([a-zA-Z][^-]*(-[a-zA-Z][^-]*)*)+(-[0-9.]|)$', r'\1', ci['compiler'])
-        host_cmplr_ver_suffix = re.sub(r'^([a-zA-Z][^-]*(-[a-zA-Z][^-]*)*)+(-[0-9.]|)$', r'\3', ci['compiler'])
-        host_cmpl_ver = host_cmplr_ver_suffix[1:]
+        print('Host compiler', ci['compiler'])
 
-        if host_ccmplr_name == 'clang':
-            print('Host compiler clang')
-            host_cppcmplr_name = re.sub(r'clang', r'clang++', host_ccmplr_name)
+        if ci['compiler'].startswith('clang'):
             with open(os.path.join(places['EPICS_BASE'], 'configure', 'os',
                                    'CONFIG_SITE.Common.'+os.environ['EPICS_HOST_ARCH']), 'a') as f:
                 f.write('''
 GNU         = NO
 CMPLR_CLASS = clang
-CC          = {0}{2}
-CCC         = {1}{2}'''.format(host_ccmplr_name, host_cppcmplr_name, host_cmplr_ver_suffix))
+CC          = {0}
+CCC         = {1}'''.format(ci['compiler'],
+                               re.sub(r'clang', r'clang++', ci['compiler'])))
 
             # hack
             with open(os.path.join(places['EPICS_BASE'], 'configure', 'CONFIG.gnuCommon'), 'a') as f:
                 f.write('''
 CMPLR_CLASS = clang''')
 
-        if host_ccmplr_name == 'gcc':
-            print('Host compiler gcc')
-            host_cppcmplr_name = re.sub(r'gcc', r'g++', host_ccmplr_name)
+        elif ci['compiler'].startswith('gcc'):
             with open(os.path.join(places['EPICS_BASE'], 'configure', 'os',
                                    'CONFIG_SITE.Common.' + os.environ['EPICS_HOST_ARCH']), 'a') as f:
                 f.write('''
-CC          = {0}{2}
-CCC         = {1}{2}'''.format(host_ccmplr_name, host_cppcmplr_name, host_cmplr_ver_suffix))
+CC          = {0}
+CCC         = {1}'''.format(ci['compiler'], re.sub(r'gcc', r'g++', ci['compiler'])))
+
+        elif ci['compiler'].startswith('vs'):
+            pass # nothing special
+
+        else:
+            raise ValueError('Unknown compiler name {0}.  valid forms include: gcc, gcc-4.8, clang, vs2019'.format(ci['compiler']))
 
         # Add additional settings to CONFIG_SITE
         extra_config = ''


### PR DESCRIPTION
`CMP="gcc-4.8"` isn't correctly propagating the "-4.8".  This seems to be a text handling issue which this PR addresses.  It also teaches `VV=1` to print all files modified prior to building dependencies.

However, with this change I start seeing a mysterious (to me) build failure on the `gcc-4.8/ubuntu-16.04` jobs.
This job succeeded (using the wrong gcc version) prior to this ci-scripts change.

eg. https://github.com/mdavidsaver/pvxs/runs/1850225898?check_suite_focus=true#step:6:1659

```
  make[4]: Entering directory '/home/runner/.cache/base-7.0/modules/libcom/src/O.linux-x86_64'
  make[4]: *** No rule to make target 'antelope', needed by '../../../../bin/linux-x86_64/antelope'.  Stop.
  make[4]: *** Waiting for unfinished jobs....
  make[3]: *** [install.linux-x86_64] Error 2
  make[2]: *** [src.install] Error 2
  make[1]: *** [libcom.install] Error 2
  make: *** [modules.install] Error 2
  DEBUG:__main__:EXEC DONE
  g++-4.8 -o antelope  -L/home/runner/.cache/base-7.0/lib/linux-x86_64 -Wl,-rpath,/home/runner/.cache/base-7.0/lib/linux-x86_64           -rdynamic -m64         closure.o error.o lalr.o lr0.o antelope.o mkpar.o output.o reader.o skeleton.o symtab.o verbose.o warshall.o       
  make[4]: Leaving directory '/home/runner/.cache/base-7.0/modules/libcom/src/O.linux-x86_64'
```

An earlier print shows that make 4.1 is being used.