### PR TITLE
Really Fix qualified GCC version builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -66,9 +66,12 @@ jobs:
     - uses: actions/checkout@v2
     - name: "apt-get install ${{ matrix.cmp }}"
       run: |
+        export GCC_NAME="${{ matrix.cmp }}"
+        sudo apt-get update
         sudo apt-get -y install software-properties-common
         sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-        sudo apt-get -y install ${{ matrix.cmp }}
+        sudo apt-get update
+        sudo apt-get -y install g++-${GCC_NAME#gcc-}
     - name: Prepare and compile dependencies
       run: python cue.py prepare
     - name: Build main module (example app)

--- a/cue-test.py
+++ b/cue-test.py
@@ -725,11 +725,7 @@ class TestSetupForBuild(unittest.TestCase):
 
     @unittest.skipIf(ci_os != 'windows', 'HostArchConfiguration test only applies to windows')
     def test_HostArchConfiguration(self):
-        # there is no combined static and debug EPICS_HOST_ARCH target,
-        # so a combined debug and static target will appear to be just static
-        # but debug will have been specified in CONFIG_SITE by prepare()
         cue.ci['compiler'] = 'vs2017'
-        cue.ci['compiler-class'] = 'vs'
         for cue.ci['debug'] in [True, False]:
             for cue.ci['static'] in [True, False]:
                 config_st = {True: 'static', False: 'shared'}
@@ -739,15 +735,11 @@ class TestSetupForBuild(unittest.TestCase):
                 self.assertTrue('EPICS_HOST_ARCH' in os.environ,
                                 'EPICS_HOST_ARCH is not set for Configuration={0}'.format(config))
                 if cue.ci['static']:
-                    # static plus anything must be *-static and not *-debug
                     self.assertTrue(re.search('-static$', os.environ['EPICS_HOST_ARCH']),
-                                    'EPICS_HOST_ARCH (found {0}) is not -static for Configuration={1}'
-                                    .format(os.environ['EPICS_HOST_ARCH'], config))
+                                    'EPICS_HOST_ARCH is not -static for Configuration={0}'.format(config))
                     self.assertFalse(re.search('debug', os.environ['EPICS_HOST_ARCH']),
-                                     'EPICS_HOST_ARCH (found {0}) is -debug for Configuration={1}'
-                                     .format(os.environ['EPICS_HOST_ARCH'], config))
+                                     'EPICS_HOST_ARCH is -debug for Configuration={0}'.format(config))
                 elif cue.ci['debug']:
-                    # debug (and not static) must be *-debug and not *-static
                     self.assertFalse(re.search('static', os.environ['EPICS_HOST_ARCH']),
                                      'EPICS_HOST_ARCH (found {0}) is -static for Configuration={1}'
                                      .format(os.environ['EPICS_HOST_ARCH'], config))
@@ -755,7 +747,6 @@ class TestSetupForBuild(unittest.TestCase):
                                     'EPICS_HOST_ARCH (found {0}) is not -debug for Configuration={1}'
                                     .format(os.environ['EPICS_HOST_ARCH'], config))
                 else:
-                    # not debug and not static
                     self.assertFalse(re.search('static', os.environ['EPICS_HOST_ARCH']),
                                      'EPICS_HOST_ARCH is -static for Configuration={0}'.format(config))
                     self.assertFalse(re.search('debug', os.environ['EPICS_HOST_ARCH']),

--- a/cue.py
+++ b/cue.py
@@ -903,15 +903,16 @@ CROSS_COMPILER_TARGET_ARCHS += RTEMS-pc386{0}'''.format(qemu_suffix))
 
         print('Host compiler', ci['compiler'])
 
+        cxx = None
         if ci['compiler'].startswith('clang'):
+            cxx = re.sub(r'clang', r'clang++', ci['compiler'])
             with open(os.path.join(places['EPICS_BASE'], 'configure', 'os',
                                    'CONFIG_SITE.Common.'+os.environ['EPICS_HOST_ARCH']), 'a') as f:
                 f.write('''
 GNU         = NO
 CMPLR_CLASS = clang
 CC          = {0}
-CCC         = {1}'''.format(ci['compiler'],
-                               re.sub(r'clang', r'clang++', ci['compiler'])))
+CCC         = {1}'''.format(ci['compiler'], cxx))
 
             # hack
             with open(os.path.join(places['EPICS_BASE'], 'configure', 'CONFIG.gnuCommon'), 'a') as f:
@@ -919,11 +920,12 @@ CCC         = {1}'''.format(ci['compiler'],
 CMPLR_CLASS = clang''')
 
         elif ci['compiler'].startswith('gcc'):
+            cxx = re.sub(r'gcc', r'g++', ci['compiler'])
             with open(os.path.join(places['EPICS_BASE'], 'configure', 'os',
                                    'CONFIG_SITE.Common.' + os.environ['EPICS_HOST_ARCH']), 'a') as f:
                 f.write('''
 CC          = {0}
-CCC         = {1}'''.format(ci['compiler'], re.sub(r'gcc', r'g++', ci['compiler'])))
+CCC         = {1}'''.format(ci['compiler'], cxx))
 
         elif ci['compiler'].startswith('vs'):
             pass # nothing special
@@ -1005,6 +1007,10 @@ PERL = C:/Strawberry/perl/bin/perl -CSD'''
         print('{0}$ {1} --version{2}'.format(ANSI_CYAN, cc, ANSI_RESET))
         sys.stdout.flush()
         sp.check_call([cc, '--version'])
+        if cxx:
+            print('{0}$ {1} --version{2}'.format(ANSI_CYAN, cxx, ANSI_RESET))
+            sys.stdout.flush()
+            sp.check_call([cxx, '--version'])
 
     if logging.getLogger().isEnabledFor(logging.DEBUG):
         log_modified()


### PR DESCRIPTION
Follow on to #58 to actually install the C++ compiler (eg. `g++-4.8`), and call `g++-4.8 --version` as an existence proof.

I started by reverting 2016cb2ae721256ff685533a55039b6143040686 and e7b1214d09115d200e16b683c262f0e371f9d7b3 since the use of `CMPLR_SUFFIX` breaks as binutils and gcc are separate packages with different versioning.  eg. There is no `ar-4.8`.

I'm marking this as a draft since I expect @ralphlange will want to do things differently.