### PR TITLE
Add vs2022

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -72,19 +72,21 @@ environment:
   VV: 1
 
   matrix:
-  - CMP: vs2019
+  - CMP: vs2022
     SET: test00
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
   - CMP: gcc
-  - CMP: vs2019
+  - CMP: vs2022
     VV: 0
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-  - CMP: vs2019
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+  - CMP: vs2022
     BASE: 3.15
     CLEAN_DEPS: NO
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-  - CMP: vs2019
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+  - CMP: vs2022
     BASE: 3.14
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+  - CMP: vs2019
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
   - CMP: vs2017
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, windows-2019, windows-2016, macos-10.15]
+        os: [ubuntu-20.04, ubuntu-18.04, ubuntu-16.04, windows-2022, windows-2019, windows-2016, macos-10.15]
     steps:
     - uses: actions/checkout@v2
     - name: Show initial environment
@@ -113,12 +113,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2019, windows-2016]
-        cmp: [gcc, vs2019, vs2017]
+        os: [windows-2022, windows-2019, windows-2016]
+        cmp: [gcc, vs2022, vs2019, vs2017]
         configuration: [default, static, debug, static-debug]
         exclude:
+          - os: windows-2022
+            cmp: vs2019
+          - os: windows-2022
+            cmp: vs2017
+
+          - os: windows-2019
+            cmp: vs2022
           - os: windows-2019
             cmp: vs2017
+
+          - os: windows-2016
+            cmp: vs2022
           - os: windows-2016
             cmp: vs2019
     steps:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ levels as the example files.
    the module can be patched or further configured.
 
  - Define shared (default) or static builds (for executables and libraries).
- 
+
  - Define optimized (default) or debug builds.
 
  - Run tests (using the EPICS build system, i.e., `make runtests`
@@ -76,7 +76,7 @@ and limitations.
  - Cross-compile for RTEMS 4.9 and 4.10 (pc386, Base >= 3.15)
  - Cross-compile for RTEMS 5 (10 BSPs, Base >= 7.0.5.1)
  - Built dependencies are cached (for faster builds).
- 
+
 See specific
 **[ci-scripts on Travis-CI README](travis/README.md)**
 for more details.
@@ -85,7 +85,7 @@ for more details.
  - One parallel runner (all builds are sequential)
  - Windows Server 2012/2016/2019
  - Compile using gcc/MinGW or different Visual Studio versions: \
-   2010, 2012, 2013, 2015, 2017, 2019
+   2010, 2012, 2013, 2015, 2017, 2019, 2022
  - Compile for Windows 32bit and 64bit
  - No useful caching available.
 
@@ -95,10 +95,10 @@ for more details.
 
 ### [GitHub Actions](https://github.com/)
  - 20 parallel runners on Linux/Windows (5 runners on MacOS)
- - Ubuntu 16/18/20, MacOS 10.15, Windows Server 2016/2019
+ - Ubuntu 16/18/20, MacOS 10.15, Windows Server 2016/2019/2022
  - Compile natively on Linux (gcc, clang)
  - Compile natively on MacOS (clang)
- - Compile natively on Windows (gcc/MinGW, Visual Studio 2017 & 2019)
+ - Compile natively on Windows (gcc/MinGW, Visual Studio 2017/2019/2022)
  - Cross-compile for Windows 32bit and 64bit using MinGW and WINE
  - Cross-compile for RTEMS 4.9 and 4.10 (pc386, Base >= 3.15)
  - Cross-compile for RTEMS 5 (10 BSPs, Base >= 7.0.5.1)
@@ -112,7 +112,7 @@ for more details.
 
  - Docker-based runners on Linux (one VM instance per job)
  - Can use any Docker image from Dockerhub (the examples use
-  `ubuntu:bionic`)
+    `ubuntu:bionic`)
  - Compile natively using different compilers (gcc, clang)
  - Cross-compile for Windows 32bit and 64bit using MinGW and WINE
  - Cross-compile for RTEMS 4.9 and 4.10 (pc386, Base >= 3.15)

--- a/appveyor/.appveyor.yml.example-full
+++ b/appveyor/.appveyor.yml.example-full
@@ -92,8 +92,8 @@ environment:
   BASE: 7.0
 
   matrix:
-  - CMP: vs2019
-    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+  - CMP: vs2022
+    APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
   - CMP: gcc
   - CMP: vs2019
     APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019

--- a/appveyor/.appveyor.yml.example-mini
+++ b/appveyor/.appveyor.yml.example-mini
@@ -20,7 +20,7 @@ skip_commits:
 install:
   - cmd: git submodule update --init --recursive
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 # Build Configurations: shared/static, optimized/debug
 configuration:
@@ -34,9 +34,9 @@ environment:
   SETUP_PATH: .ci-local:.ci
 
   matrix:
-  - CMP: vs2019
+  - CMP: vs2022
     BASE: 7.0
-  - CMP: vs2019
+  - CMP: vs2022
     BASE: 3.15
 
 # Platform: processor architecture

--- a/appveyor/README.md
+++ b/appveyor/README.md
@@ -5,7 +5,7 @@
  - One parallel runner (all builds are sequential)
  - Windows Server 2012/2016/2019
  - Compile using gcc/MinGW or different Visual Studio versions: \
-   2010, 2012, 2013, 2015, 2017, 2019
+   2010, 2012, 2013, 2015, 2017, 2019, 2022
  - Compile for Windows 32bit and 64bit
  - No useful caching available.
 
@@ -46,7 +46,7 @@
     List of environment variable settings. Each list element (starting with
     a dash) is one step on the axis of the build matrix. \
     Set `CMP` to select the compiler: `gcc` for the native
-    [MinGW](http://mingw-w64.org/) GNU compiler, `vs2010` ...`vs2019` 
+    [MinGW](http://mingw-w64.org/) GNU compiler, `vs2010` ...`vs2022`
     (options listed above) for the Microsoft Visual Studio compilers.
 
     Your builds will take long. \

--- a/cue-test.py
+++ b/cue-test.py
@@ -349,8 +349,10 @@ class TestVCVars(unittest.TestCase):
             os.environ['CONFIGURATION'] = 'default'
             if ci_service == 'github-actions' and os.environ['IMAGEOS'] == 'win16':
                 os.environ['CMP'] = 'vs2017'
-            else:
+            elif ci_service == 'github-actions' and os.environ['IMAGEOS'] == 'win19':
                 os.environ['CMP'] = 'vs2019'
+            else:
+                os.environ['CMP'] = 'vs2022'
         cue.detect_context()
         cue.with_vcvars('env')
 

--- a/cue.py
+++ b/cue.py
@@ -266,6 +266,8 @@ toolsdir = os.path.join(homedir, '.tools')
 
 vcvars_table = {
     # https://en.wikipedia.org/wiki/Microsoft_Visual_Studio#History
+    'vs2022': [r'C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat',
+               r'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'],
     'vs2019': [r'C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat',
                r'C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat'],
     'vs2017': [r'C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat',

--- a/github-actions/README.md
+++ b/github-actions/README.md
@@ -6,7 +6,7 @@
  - Ubuntu 16/18/20, MacOS 10.15, Windows Server 2016/2019
  - Compile natively on Linux (gcc, clang)
  - Compile natively on MacOS (clang)
- - Compile natively on Windows (gcc/MinGW, Visual Studio 2017 & 2019)
+ - Compile natively on Windows (gcc/MinGW, Visual Studio 2017/2019/2022)
  - Cross-compile for Windows 32bit and 64bit using MinGW and WINE
  - Cross-compile for RTEMS 4.9 and 4.10 (pc386, Base >= 3.15)
  - Cross-compile for RTEMS 5 (10 BSPs, Base >= 7.0.5.1)

--- a/github-actions/ci-scripts-build.yml.example-full
+++ b/github-actions/ci-scripts-build.yml.example-full
@@ -166,6 +166,16 @@ jobs:
             configuration: static
             name: "Win2019 MSC-19, static"
 
+          - os: windows-2022
+            cmp: vs2022
+            configuration: default
+            name: "Win2022 MSC-22"
+
+          - os: windows-2022
+            cmp: vs2022
+            configuration: static
+            name: "Win2022 MSC-22, static"
+
     steps:
     - uses: actions/checkout@v2
       with:


### PR DESCRIPTION
Add `vs2022` version, which appears in recent [Windows 11 VM images](https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/).