### PR TITLE
GHA update to actions/checkout@v3

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         os: [ubuntu-22.04, ubuntu-20.04, ubuntu-18.04, windows-2022, windows-2019, macos-12, macos-11]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Show initial environment
       run: python cue-test.py env
     - name: Run unit tests
@@ -40,7 +40,7 @@ jobs:
         cmp: [gcc, clang]
         configuration: [default, static, debug, static-debug]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Prepare and compile dependencies
       run: python cue.py prepare
     - name: Build main module (example app)
@@ -63,7 +63,7 @@ jobs:
         cmp: [clang]
         configuration: [default, debug]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Prepare and compile dependencies
       run: python cue.py prepare
     - name: Build main module (example app)
@@ -93,7 +93,7 @@ jobs:
             cmp: vs2022
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Prepare and compile dependencies
       run: python cue.py prepare
     - name: Build main module (example app)
@@ -128,7 +128,7 @@ jobs:
         - RTEMS-pc386-qemu@4.10
         - RTEMS-pc686-qemu@5
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Prepare and compile dependencies
       run: python cue.py prepare
     - name: Build main module (example app)

--- a/github-actions/ci-scripts-build.yml.example-full
+++ b/github-actions/ci-scripts-build.yml.example-full
@@ -160,7 +160,7 @@ jobs:
             name: "Win2022 MSC-22, static"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Automatic core dumper analysis
@@ -216,7 +216,7 @@ jobs:
         - RTEMS-pc386-qemu@4.10
         - RTEMS-pc686-qemu@5
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Prepare and compile dependencies
       run: python cue.py prepare
     - name: Build main module


### PR DESCRIPTION
Quiets the deprecation warnings which have recently appeared.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

https://github.com/actions/checkout
