### PR TITLE
add --add-env argument for appending to generic environment variables

### DIFF
--- a/cue-test.py
+++ b/cue-test.py
@@ -702,7 +702,7 @@ class TestAppveyorDetectContext(unittest.TestCase):
 
 
 class TestSetupForBuild(unittest.TestCase):
-    args = Namespace(paths=[])
+    args = Namespace(extra_env_vars=[])
     if ci_os == 'windows':
         choco_installs = ['make']
         if ci_service != 'appveyor':
@@ -721,7 +721,7 @@ class TestSetupForBuild(unittest.TestCase):
 
     def test_AddPathsOption(self):
         os.environ['FOOBAR'] = 'BAR'
-        args = Namespace(paths=['/my/{FOOBAR}/dir', '/my/foobar'])
+        args = Namespace(extra_env_vars=['PATH=/my/{FOOBAR}/dir', 'PATH=/my/foobar'])
         cue.setup_for_build(args)
         self.assertTrue(re.search('/my/BAR/dir', os.environ['PATH']), 'Expanded path not in PATH')
         self.assertTrue(re.search('/foobar', os.environ['PATH']), 'Plain path not in PATH')
@@ -887,7 +887,7 @@ LINE2=NO''')
 
 @unittest.skipIf(ci_os != 'linux', 'CrossCompatibilityHandling tests only apply to linux')
 class TestCrossCompatibilityHandling(unittest.TestCase):
-    args = Namespace(paths=[])
+    args = Namespace(extra_env_vars=[])
 
     def setUp(self):
         cue.clear_lists()


### PR DESCRIPTION
Useful for the `exec` verb.

Not completely sure if the move of these lines have an impact:

```python
    os.environ['MAKE'] = 'make'
    os.environ['EPICS_BASE'] = places['EPICS_BASE']
```

From a discussion with @mdavidsaver 