### PR TITLE
enable compiler color output if available

### DIFF
--- a/cue.py
+++ b/cue.py
@@ -1209,6 +1209,15 @@ PERL = C:/Strawberry/perl/bin/perl -CSD'''
             with open(os.path.join(places['EPICS_BASE'], 'configure', 'CONFIG_SITE'), 'a') as f:
                 f.write(extra_config)
 
+        # enable color in error and warning messages if the (cross) compiler supports it
+        with open(os.path.join(places['EPICS_BASE'], 'configure', 'CONFIG'), 'a') as f:
+            f.write('''
+ifdef T_A
+  COLOR_FLAG_$(T_A) := $(shell $(CPP) -fdiagnostics-color -E - </dev/null >/dev/null 2>/dev/null && echo -fdiagnostics-color)
+  $(info Checking if $(CPP) supports -fdiagnostics-color: $(if $(COLOR_FLAG_$(T_A)),yes,no))
+  USR_CPPFLAGS += $(COLOR_FLAG_$(T_A))
+endif''')
+
         fold_end('set.up.epics_build', 'Configuring EPICS build system')
 
     if ci['os'] == 'windows' and ci['choco']:


### PR DESCRIPTION
Newer gcc and clang support colored warning and error messages. This makes it easier to find warning in the bulk of make output. Unfortunately, this is disabled by default in a CI environment like github workers, because the compiler only colorizes its output to a terminal, which is not the case here. But it can be enabled explicitly with the flag`-fdiagnostics-color` in both, gcc and clang, provided the compiler is new enough to support colors.

This merge requests enables the `-fdiagnostics-colors` flag if the (cross) compiler supports it. This is tested at the end of `CONFIG`, after the (cross) compiler has been set up. If other compilers support other flags to enable colors, those may be added later.

I have added this feature in this ci-scripts repo only and not in EPICS base, because I do not want to add `-fdiagnostics-colors` to "normal" compilations in user's environments, because they may break if color is added unexpectedly.

To see this feature in action, see https://github.com/epics-base/ci-scripts/actions/runs/5044562166/jobs/9047768964?pr=79#step:4:217 or my EPICS base run with this change enabled: https://github.com/dirk-zimoch/epics-base/actions/runs/5044238284