### PR TITLE
Update default sequencer url

### DIFF
--- a/defaults.set
+++ b/defaults.set
@@ -18,7 +18,7 @@ NTYPES_REPONAME=normativeTypesCPP
 NTYPES_REPOOWNER=epics-base
 
 # Sequencer
-SNCSEQ_REPOURL=https://www-csr.bessy.de/control/SoftDist/sequencer/repo/branch-2-2.git
+SNCSEQ_REPOURL=https://github.com/mdavidsaver/sequencer-mirror.git
 SNCSEQ_DEPTH=0
 SNCSEQ_DIRNAME=seq
 


### PR DESCRIPTION
Due to issues at CSR-bessy, sequencer is no longer hosted there. M. Davidsaver is currently maintaining a mirror of that repository, which we can point to instead.