### PR TITLE
fix GHA example error and warning

### DIFF
--- a/github-actions/ci-scripts-build.yml.example-mini
+++ b/github-actions/ci-scripts-build.yml.example-mini
@@ -31,6 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+      include:
         - os: ubuntu-18.04
           cmp: gcc
           configuration: default
@@ -68,7 +69,7 @@ jobs:
           name: "3.15 Ub-20 clang-10"
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Prepare and compile dependencies


### PR DESCRIPTION
fixed Invalid workflow file error of `github-actions/ci-scripts-build.yml.example-mini`, also update version of actions/checkout