### PR TITLE
Workaround for chocolatey CLI issues

### DIFF
--- a/cue-test.py
+++ b/cue-test.py
@@ -707,7 +707,7 @@ class TestSetupForBuild(unittest.TestCase):
         choco_installs = ['make']
         if ci_service != 'appveyor':
             choco_installs.append('strawberryperl')
-        sp.check_call(['choco', 'install', '-ry'] + choco_installs)
+        sp.check_call(['choco', 'install', '-ry'] + choco_installs + ['-y', '--limitoutput', '--no-progress', '-u', '""', '-p', '""'])
 
     def setUp(self):
         cue.building_base = True

--- a/cue.py
+++ b/cue.py
@@ -1237,7 +1237,7 @@ endif''')
         fold_start('install.choco', 'Installing CHOCO packages')
         for i in range(0,3):
             try:
-                sp.check_call(['choco', 'install'] + ci['choco'] + ['-y', '--limitoutput', '--no-progress'])
+                sp.check_call(['choco', 'install'] + ci['choco'] + ['-y', '--limitoutput', '--no-progress', '-u', '""', '-p', '""'])
             except Exception as e:
                 print(e)
                 print("Retrying choco install attempt {} after 30 seconds".format(i+1))


### PR DESCRIPTION
Authentication using the chocolatey CLI v2 sometimes asks for authentication even if none is required.
Supplying empty user and password should work around that bug.