### PR TITLE
Skip using libreadline for base 3.14

### DIFF
--- a/cue.py
+++ b/cue.py
@@ -618,6 +618,13 @@ def add_dependency(dep):
                         sys.stdout.flush()
                         sp.check_call(['patch', '-p1', '-i', os.path.join(ci['scriptsdir'], 'add-msi-to-314.patch')],
                                       cwd=place)
+
+                        # Post 3.14 we have checks for readline.h
+                        print('Patching COMMANDLINE_LIBRARY to EPICS')
+                        sys.stdout.flush()
+                        sp.check_call(['patch', '-p1', '-i', os.path.join(ci['scriptsdir'], 'dont_use_readline_314.patch')],
+                                      cwd=place)
+
         else:
             # force including RELEASE.local for non-base modules by overwriting their configure/RELEASE
             release = os.path.join(place, "configure", "RELEASE")

--- a/dont_use_readline_314.patch
+++ b/dont_use_readline_314.patch
@@ -1,0 +1,13 @@
+diff --git a/configure/os/CONFIG_SITE.Common.linux-x86 b/configure/os/CONFIG_SITE.Common.linux-x86
+index 6c3a8308a..9c90967ec 100644
+--- a/configure/os/CONFIG_SITE.Common.linux-x86
++++ b/configure/os/CONFIG_SITE.Common.linux-x86
+@@ -22,7 +22,7 @@
+ # comment them all out to build without readline support.
+ 
+ # No other libraries needed (recent Fedora, Ubuntu etc.):
+-COMMANDLINE_LIBRARY = READLINE
++#COMMANDLINE_LIBRARY = READLINE
+ 
+ # Needs -lncurses (RHEL 5 etc.):
+ #COMMANDLINE_LIBRARY = READLINE_NCURSES


### PR DESCRIPTION
In base 3.15 onwards we have checks for the existence of readline.h. For base 3.14 we should just skip it.

See e.g. the failing jobs on https://github.com/epics-modules/iocStats/pull/73