### PR TITLE
CI: add v3 builds

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,17 +28,43 @@ jobs:
       run: python3 cue-test.py
 
   build-linux:
-    name: ${{ matrix.cmp }} / ${{ matrix.configuration }} / ${{ matrix.os }}
+    name: B-${{ matrix.base }} ${{ matrix.cmp }} ${{ matrix.configuration }} @ ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
+      BASE: ${{ matrix.base }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-24.04, ubuntu-22.04]
         cmp: [gcc, clang]
         configuration: [default, static, debug, static-debug]
+        base: ["7.0"]
+        include:
+          - os: ubuntu-24.04
+            cmp: gcc
+            configuration: default
+            base: "3.15"
+            name: "B-3.15 Ub-24 gcc-13"
+
+          - os: ubuntu-24.04
+            cmp: gcc
+            configuration: static
+            base: "3.15"
+            name: "B-3.15 Ub-24 gcc-13, static"
+
+          - os: ubuntu-24.04
+            cmp: gcc
+            configuration: default
+            base: "3.14"
+            name: "B-3.14 Ub-24 gcc-13"
+
+          - os: ubuntu-24.04
+            cmp: gcc
+            configuration: static
+            base: "3.14"
+            name: "B-3.14 Ub-24 gcc-13, static"
     steps:
     - uses: actions/checkout@v4
     - name: Prepare and compile dependencies
@@ -51,17 +77,32 @@ jobs:
       run: python cue.py test-results
 
   build-macos:
-    name: ${{ matrix.cmp }} / ${{ matrix.configuration }} / ${{ matrix.os }}
+    name: B-${{ matrix.base }} ${{ matrix.cmp }} ${{ matrix.configuration }} @ ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
+      BASE: ${{ matrix.base }}
     strategy:
       fail-fast: false
       matrix:
         os: [macos-15, macos-14]
         cmp: [clang]
         configuration: [default, debug]
+        base: ["7.0"]
+        include:
+          - os: macos-15
+            cmp: clang
+            configuration: default
+            base: "3.15"
+            name: "B-3.15 Mac-15"
+
+# Base 3.14 does not support MacOS-aarch64
+#          - os: macos-15
+#            cmp: clang
+#            configuration: default
+#            base: "3.14"
+#            name: "B-3.14 Mac-15"
     steps:
     - uses: actions/checkout@v4
     - name: Prepare and compile dependencies
@@ -74,18 +115,31 @@ jobs:
       run: python cue.py test-results
 
   build-windows:
-    name: ${{ matrix.cmp }} / ${{ matrix.configuration }} / ${{ matrix.os }}
+    name: B-${{ matrix.base }} ${{ matrix.cmp }} ${{ matrix.configuration }} @ ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     env:
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
+      BASE: ${{ matrix.base }}
     strategy:
       fail-fast: false
       matrix:
         os: [windows-2025, windows-2022]
         cmp: [gcc, vs2022]
         configuration: [default, static, debug, static-debug]
+        base: [ "7.0" ]
+        include:
+          - os: windows-2025
+            cmp: vs2022
+            configuration: static
+            base: "3.15"
+            name: "B-3.15 Win-25 MSC-22 static"
 
+          - os: windows-2025
+            cmp: vs2022
+            configuration: static
+            base: "3.14"
+            name: "B-3.14 Win-25 MSC-22 static"
     steps:
     - uses: actions/checkout@v4
     - name: Prepare and compile dependencies

--- a/dont_use_readline_314.patch
+++ b/dont_use_readline_314.patch
@@ -1,7 +1,18 @@
-diff --git a/configure/os/CONFIG_SITE.Common.linux-x86 b/configure/os/CONFIG_SITE.Common.linux-x86
-index 6c3a8308a..9c90967ec 100644
---- a/configure/os/CONFIG_SITE.Common.linux-x86
-+++ b/configure/os/CONFIG_SITE.Common.linux-x86
+diff -urN a/configure/os/CONFIG_SITE.Common.linux-x86 b/configure/os/CONFIG_SITE.Common.linux-x86
+--- a/configure/os/CONFIG_SITE.Common.linux-x86	2023-02-08 18:55:20.000000000 +0100
++++ b/configure/os/CONFIG_SITE.Common.linux-x86	2025-12-02 10:56:20.064200334 +0100
+@@ -22,7 +22,7 @@
+ # comment them all out to build without readline support.
+ 
+ # No other libraries needed (recent Fedora, Ubuntu etc.):
+-COMMANDLINE_LIBRARY = READLINE
++#COMMANDLINE_LIBRARY = READLINE
+ 
+ # Needs -lncurses (RHEL 5 etc.):
+ #COMMANDLINE_LIBRARY = READLINE_NCURSES
+diff -urN a/configure/os/CONFIG_SITE.Common.linux-x86_64 b/configure/os/CONFIG_SITE.Common.linux-x86_64
+--- a/configure/os/CONFIG_SITE.Common.linux-x86_64	2023-02-08 18:55:20.000000000 +0100
++++ b/configure/os/CONFIG_SITE.Common.linux-x86_64	2025-12-02 10:56:28.328188418 +0100
 @@ -22,7 +22,7 @@
  # comment them all out to build without readline support.
  


### PR DESCRIPTION
Adds a few CI builds for EPICS V3.

@simon-ess: like that?
I'm not sure if there are cross builds that would work with V3.